### PR TITLE
fix types

### DIFF
--- a/src/createAtomCreators.ts
+++ b/src/createAtomCreators.ts
@@ -1,6 +1,6 @@
-import { createTRPCClient } from '@trpc/client';
+import { createTRPCClient, TRPCRequestOptions } from '@trpc/client';
 import type { CreateTRPCClientOptions } from '@trpc/client';
-import type { AnyRouter } from '@trpc/server';
+import type { AnyRouter, inferHandlerInput } from '@trpc/server';
 
 import { atom } from 'jotai';
 import type { Getter } from 'jotai';
@@ -8,15 +8,23 @@ import type { Getter } from 'jotai';
 const isGetter = <T>(v: T | ((get: Getter) => T)): v is (get: Getter) => T =>
   typeof v === 'function';
 
+type ArgsOrGetter<T> = T | ((get: Getter) => T);
+
 export function createAtomCreators<TRouter extends AnyRouter>(
   opts: CreateTRPCClientOptions<TRouter>,
 ) {
   const client = createTRPCClient<TRouter>(opts);
 
-  type Args = Parameters<typeof client.query>;
-
-  const atomWithQuery = (
-    getArgs: Args | ((get: Getter) => Args),
+  type TQueries = TRouter['_def']['queries'];
+  const atomWithQuery = <
+    TPath extends keyof TRouter['_def']['queries'] & string,
+  >(
+    getArgs: ArgsOrGetter<
+      [
+        path: TPath,
+        ...args: [...inferHandlerInput<TQueries[TPath]>, TRPCRequestOptions?],
+      ]
+    >,
     getClient?: (get: Getter) => typeof client,
   ) => {
     const queryAtom = atom(async (get) => {

--- a/src/createAtomCreators.ts
+++ b/src/createAtomCreators.ts
@@ -16,9 +16,7 @@ export function createAtomCreators<TRouter extends AnyRouter>(
   const client = createTRPCClient<TRouter>(opts);
 
   type TQueries = TRouter['_def']['queries'];
-  const atomWithQuery = <
-    TPath extends keyof TQueries & string,
-  >(
+  const atomWithQuery = <TPath extends keyof TQueries & string>(
     getArgs: ArgsOrGetter<
       [
         path: TPath,

--- a/src/createAtomCreators.ts
+++ b/src/createAtomCreators.ts
@@ -17,7 +17,7 @@ export function createAtomCreators<TRouter extends AnyRouter>(
 
   type TQueries = TRouter['_def']['queries'];
   const atomWithQuery = <
-    TPath extends keyof TRouter['_def']['queries'] & string,
+    TPath extends keyof TQueries & string,
   >(
     getArgs: ArgsOrGetter<
       [


### PR DESCRIPTION
The current types only work with one procedure. By taking the path as a generic, input and output type inference works for multiple procedures.