### PR TITLE
breaking: split path from args

### DIFF
--- a/examples/01_typescript/src/App.tsx
+++ b/examples/01_typescript/src/App.tsx
@@ -10,7 +10,7 @@ const { atomWithQuery } = createAtomCreators<AppRouter>({
 
 const nameAtom = atom('name');
 
-const greetAtom = atomWithQuery((get) => ['greet', get(nameAtom)]);
+const greetAtom = atomWithQuery('greet', (get) => [get(nameAtom)]);
 
 const Greet = () => {
   const [data] = useAtom(greetAtom);

--- a/src/createAtomCreators.ts
+++ b/src/createAtomCreators.ts
@@ -17,18 +17,16 @@ export function createAtomCreators<TRouter extends AnyRouter>(
 
   type TQueries = TRouter['_def']['queries'];
   const atomWithQuery = <TPath extends keyof TQueries & string>(
+    path: TPath,
     getArgs: ArgsOrGetter<
-      [
-        path: TPath,
-        ...args: [...inferHandlerInput<TQueries[TPath]>, TRPCRequestOptions?],
-      ]
+      [...inferHandlerInput<TQueries[TPath]>, TRPCRequestOptions?]
     >,
     getClient?: (get: Getter) => typeof client,
   ) => {
     const queryAtom = atom(async (get) => {
       const args = isGetter(getArgs) ? getArgs(get) : getArgs;
       const currentClient = getClient ? getClient(get) : client;
-      const result = await currentClient.query(...args);
+      const result = await currentClient.query(path, ...args);
       return result;
     });
     return queryAtom;


### PR DESCRIPTION
From #1, I think this should be clearer. And, maybe better for v10 migration.
cc @sachinraja 