### PR TITLE
feat: trpc v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "@testing-library/jest-dom": "^6.4.5",
     "@testing-library/react": "^15.0.7",
     "@testing-library/user-event": "^14.5.2",
-    "@trpc/client": "^10.45.2",
-    "@trpc/server": "^10.45.2",
+    "@trpc/client": "^11.0.0-rc.467",
+    "@trpc/server": "^11.0.0-rc.467",
     "@types/node": "^20.12.12",
     "@types/react": "^18.3.2",
     "@types/react-dom": "^18.3.0",
@@ -84,8 +84,8 @@
     "vitest": "^1.6.0"
   },
   "peerDependencies": {
-    "@trpc/client": ">=10.0.0",
-    "@trpc/server": ">=10.0.0",
+    "@trpc/client": ">=11.0.0",
+    "@trpc/server": ">=11.0.0",
     "jotai": ">=2.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ devDependencies:
     specifier: ^14.5.2
     version: 14.5.2(@testing-library/dom@10.1.0)
   '@trpc/client':
-    specifier: ^10.45.2
-    version: 10.45.2(@trpc/server@10.45.2)
+    specifier: ^11.0.0-rc.467
+    version: 11.0.0-rc.467(@trpc/server@11.0.0-rc.467)
   '@trpc/server':
-    specifier: ^10.45.2
-    version: 10.45.2
+    specifier: ^11.0.0-rc.467
+    version: 11.0.0-rc.467
   '@types/node':
     specifier: ^20.12.12
     version: 20.12.12
@@ -79,7 +79,7 @@ devDependencies:
     version: 4.0.13(react@18.3.1)
   trpc-pokemon:
     specifier: ^2.0.0-next.0
-    version: 2.0.0-next.0(@trpc/server@10.45.2)
+    version: 2.0.0-next.0(@trpc/server@11.0.0-rc.467)
   ts-expect:
     specifier: ^1.3.0
     version: 1.3.0
@@ -631,16 +631,16 @@ packages:
       '@testing-library/dom': 10.1.0
     dev: true
 
-  /@trpc/client@10.45.2(@trpc/server@10.45.2):
-    resolution: {integrity: sha512-ykALM5kYWTLn1zYuUOZ2cPWlVfrXhc18HzBDyRhoPYN0jey4iQHEFSEowfnhg1RvYnrAVjNBgHNeSAXjrDbGwg==}
+  /@trpc/client@11.0.0-rc.467(@trpc/server@11.0.0-rc.467):
+    resolution: {integrity: sha512-ovZaGdAUl+EEmtJJc5uuo95B0gw8+q3jwNjUQQmmSMU5Isq4sYdjIWNkhbrFtR8CovllFyrRrjAgCWdaOTEY4g==}
     peerDependencies:
-      '@trpc/server': 10.45.2
+      '@trpc/server': 11.0.0-rc.467+8f72171d6
     dependencies:
-      '@trpc/server': 10.45.2
+      '@trpc/server': 11.0.0-rc.467
     dev: true
 
-  /@trpc/server@10.45.2:
-    resolution: {integrity: sha512-wOrSThNNE4HUnuhJG6PfDRp4L2009KDVxsd+2VYH8ro6o/7/jwYZ8Uu5j+VaW+mOmc8EHerHzGcdbGNQSAUPgg==}
+  /@trpc/server@11.0.0-rc.467:
+    resolution: {integrity: sha512-94Gv26ALuBfxgFlSGV3x2uF2ixUEViuK0m3IPKOvCTMreisZkBqyTa3NkBcuPZW/AMUieM5P4Q2NrbHTIA0fKQ==}
     dev: true
 
   /@types/aria-query@5.0.4:
@@ -3069,12 +3069,12 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /trpc-pokemon@2.0.0-next.0(@trpc/server@10.45.2):
+  /trpc-pokemon@2.0.0-next.0(@trpc/server@11.0.0-rc.467):
     resolution: {integrity: sha512-TBcouSU77UyzYf9sh4JRrlS3iAsM7Q74G2l/Moxq64HFfwmqR4lvbVQMnb8TYE1n+WHKOPfX2EU4JZqK+CewlA==}
     peerDependencies:
       '@trpc/server': ^10.0.0-rc.4
     dependencies:
-      '@trpc/server': 10.45.2
+      '@trpc/server': 11.0.0-rc.467
     dev: true
 
   /ts-api-utils@1.3.0(typescript@5.4.5):

--- a/src/createTRPCJotai.ts
+++ b/src/createTRPCJotai.ts
@@ -1,4 +1,4 @@
-import { createTRPCProxyClient } from '@trpc/client';
+import { createTRPCClient } from '@trpc/client';
 import type { TRPCRequestOptions, CreateTRPCClientOptions } from '@trpc/client';
 import type {
   AnyMutationProcedure,
@@ -201,7 +201,7 @@ type DecoratedProcedureRecord<
 export function createTRPCJotai<TRouter extends AnyRouter>(
   opts: CreateTRPCClientOptions<TRouter>,
 ) {
-  const client = createTRPCProxyClient<TRouter>(opts);
+  const client = createTRPCClient<TRouter>(opts);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const createProxy = (target: any, path: readonly string[] = []): any => {

--- a/src/createTRPCJotai.ts
+++ b/src/createTRPCJotai.ts
@@ -1,11 +1,11 @@
 import { createTRPCClient } from '@trpc/client';
 import type { TRPCRequestOptions, CreateTRPCClientOptions } from '@trpc/client';
 import type {
-  AnyMutationProcedure,
-  AnyProcedure,
-  AnyQueryProcedure,
-  AnySubscriptionProcedure,
-  AnyRouter,
+  AnyTRPCMutationProcedure,
+  AnyTRPCProcedure,
+  AnyTRPCQueryProcedure,
+  AnyTRPCSubscriptionProcedure,
+  AnyTRPCRouter,
   ProcedureArgs,
   ProcedureRouterRecord,
   inferProcedureInput,
@@ -39,7 +39,7 @@ export const DISABLED = Symbol();
 
 type CustomOptions = { disabledOutput?: unknown };
 
-const atomWithQuery = <TProcedure extends AnyQueryProcedure, TClient>(
+const atomWithQuery = <TProcedure extends AnyTRPCQueryProcedure, TClient>(
   path: string[],
   getClient: (get: Getter) => TClient,
   getInput: AsyncValueOrGetter<
@@ -69,7 +69,7 @@ const atomWithQuery = <TProcedure extends AnyQueryProcedure, TClient>(
   return queryAtom;
 };
 
-const atomWithMutation = <TProcedure extends AnyMutationProcedure, TClient>(
+const atomWithMutation = <TProcedure extends AnyTRPCMutationProcedure, TClient>(
   path: string[],
   getClient: (get: Getter) => TClient,
 ) => {
@@ -88,7 +88,7 @@ const atomWithMutation = <TProcedure extends AnyMutationProcedure, TClient>(
 };
 
 const atomWithSubscription = <
-  TProcedure extends AnySubscriptionProcedure,
+  TProcedure extends AnyTRPCSubscriptionProcedure,
   TClient,
 >(
   path: string[],
@@ -122,7 +122,7 @@ const atomWithSubscription = <
   return subscriptionAtom;
 };
 
-type QueryResolver<TProcedure extends AnyProcedure, TClient> = {
+type QueryResolver<TProcedure extends AnyTRPCProcedure, TClient> = {
   (
     getInput: AsyncValueOrGetter<ProcedureArgs<TProcedure['_def']>[0]>,
     getOptions?: ValueOrGetter<ProcedureArgs<TProcedure['_def']>[1]>,
@@ -156,7 +156,7 @@ type QueryResolver<TProcedure extends AnyProcedure, TClient> = {
   >;
 };
 
-type MutationResolver<TProcedure extends AnyProcedure, TClient> = (
+type MutationResolver<TProcedure extends AnyTRPCProcedure, TClient> = (
   getClient?: (get: Getter) => TClient,
 ) => WritableAtom<
   inferProcedureOutput<TProcedure> | null,
@@ -164,24 +164,24 @@ type MutationResolver<TProcedure extends AnyProcedure, TClient> = (
   Promise<inferProcedureOutput<TProcedure>>
 >;
 
-type SubscriptionResolver<TProcedure extends AnyProcedure, TClient> = (
+type SubscriptionResolver<TProcedure extends AnyTRPCProcedure, TClient> = (
   getInput: ValueOrGetter<ProcedureArgs<TProcedure['_def']>[0]>,
   getOptions?: ValueOrGetter<ProcedureArgs<TProcedure['_def']>[1]>,
   getClient?: (get: Getter) => TClient,
 ) => Atom<inferObservableValue<inferProcedureOutput<TProcedure>>>;
 
 type DecorateProcedure<
-  TProcedure extends AnyProcedure,
+  TProcedure extends AnyTRPCProcedure,
   TClient,
-> = TProcedure extends AnyQueryProcedure
+> = TProcedure extends AnyTRPCQueryProcedure
   ? {
       atomWithQuery: QueryResolver<TProcedure, TClient>;
     }
-  : TProcedure extends AnyMutationProcedure
+  : TProcedure extends AnyTRPCMutationProcedure
     ? {
         atomWithMutation: MutationResolver<TProcedure, TClient>;
       }
-    : TProcedure extends AnySubscriptionProcedure
+    : TProcedure extends AnyTRPCSubscriptionProcedure
       ? {
           atomWithSubscription: SubscriptionResolver<TProcedure, TClient>;
         }
@@ -191,14 +191,14 @@ type DecoratedProcedureRecord<
   TProcedures extends ProcedureRouterRecord,
   TClient,
 > = {
-  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
+  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyTRPCRouter
     ? DecoratedProcedureRecord<TProcedures[TKey]['_def']['record'], TClient>
-    : TProcedures[TKey] extends AnyProcedure
+    : TProcedures[TKey] extends AnyTRPCProcedure
       ? DecorateProcedure<TProcedures[TKey], TClient>
       : never;
 };
 
-export function createTRPCJotai<TRouter extends AnyRouter>(
+export function createTRPCJotai<TRouter extends AnyTRPCRouter>(
   opts: CreateTRPCClientOptions<TRouter>,
 ) {
   const client = createTRPCClient<TRouter>(opts);


### PR DESCRIPTION
#24 

This at least demonstrates an example of some of the changes - they don't seem to be massive. With v11 not being stable yet however, it may not be worth merging this PR.

Doesn't seem to fix the examples, but I've not looked in to that yet, was just a pure port from the changelog.

```
. test:types:examples$ tsc -p examples --noEmit
│ examples/01_typescript/src/app.tsx(31,54): error TS7006: Parameter 'get' implicitly has an 'any' type.
│ examples/02_authtoken/src/app.tsx(37,4): error TS7006: Parameter 'get' implicitly has an 'any' type.
│ examples/02_authtoken/src/app.tsx(44,18): error TS7006: Parameter 'item' implicitly has an 'any' type.
└─ Failed in 863ms at /Users/lukeramsden/workspace/jotai-trpc
. test:spec$ vitest run
└─ Running...
 ELIFECYCLE  Command failed with exit code 2.
 ELIFECYCLE  Test failed. See above for more details.
```