### PR TITLE
Update to trpc@11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jotai-trpc",
   "description": "👻🧊",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "type": "module",
   "author": "Daishi Kato",
   "repository": {
@@ -57,8 +57,8 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",
-    "@trpc/client": "^10.45.2",
-    "@trpc/server": "^10.45.2",
+    "@trpc/client": "^11.1.0",
+    "@trpc/server": "^11.1.0",
     "@types/node": "^22.10.10",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
@@ -85,8 +85,8 @@
     "vitest": "^3.0.4"
   },
   "peerDependencies": {
-    "@trpc/client": ">=10.0.0",
-    "@trpc/server": ">=10.0.0",
+    "@trpc/client": ">=11.0.0",
+    "@trpc/server": ">=11.0.0",
     "jotai": ">=2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-plugin-react-compiler": "19.0.0-beta-decd7b8-20250118",
     "eslint-plugin-react-hooks": "5.2.0-canary-de1eaa26-20250124",
     "happy-dom": "^16.7.2",
-    "jotai": "^2.11.1",
+    "jotai": "^2.12.3",
     "jotai-trpc": "link:",
     "prettier": "^3.4.2",
     "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jotai-trpc",
   "description": "👻🧊",
-  "version": "0.8.0",
+  "version": "0.7.1",
   "type": "module",
   "author": "Daishi Kato",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ importers:
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
       '@trpc/client':
-        specifier: ^10.45.2
-        version: 10.45.2(@trpc/server@10.45.2)
+        specifier: ^11.1.0
+        version: 11.1.0(@trpc/server@11.1.0(typescript@5.7.3))(typescript@5.7.3)
       '@trpc/server':
-        specifier: ^10.45.2
-        version: 10.45.2
+        specifier: ^11.1.0
+        version: 11.1.0(typescript@5.7.3)
       '@types/node':
         specifier: ^22.10.10
         version: 22.10.10
@@ -79,7 +79,7 @@ importers:
         version: 5.0.0(react@19.0.0)
       trpc-pokemon:
         specifier: 2.0.0-next.0
-        version: 2.0.0-next.0(@trpc/server@10.45.2)
+        version: 2.0.0-next.0(@trpc/server@11.1.0(typescript@5.7.3))
       ts-expect:
         specifier: ^1.3.0
         version: 1.3.0
@@ -579,13 +579,16 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@trpc/client@10.45.2':
-    resolution: {integrity: sha512-ykALM5kYWTLn1zYuUOZ2cPWlVfrXhc18HzBDyRhoPYN0jey4iQHEFSEowfnhg1RvYnrAVjNBgHNeSAXjrDbGwg==}
+  '@trpc/client@11.1.0':
+    resolution: {integrity: sha512-Q3pL4p7AddxI/ZJTEFo1utKSdasDFjZPECIPsKDkthEt52k530JkYVltTdLkYFKrNWXKKBo8MN7NwchelczoRw==}
     peerDependencies:
-      '@trpc/server': 10.45.2
+      '@trpc/server': 11.1.0
+      typescript: '>=5.7.2'
 
-  '@trpc/server@10.45.2':
-    resolution: {integrity: sha512-wOrSThNNE4HUnuhJG6PfDRp4L2009KDVxsd+2VYH8ro6o/7/jwYZ8Uu5j+VaW+mOmc8EHerHzGcdbGNQSAUPgg==}
+  '@trpc/server@11.1.0':
+    resolution: {integrity: sha512-uAJ7ikejeujVkf53XFJ/0W8nr7bDjul+Szk5Rsepq97Hb/WS1RkRXdyX4KqAyCE9b1vDFCJVJwSxiIZdRtbTZQ==}
+    peerDependencies:
+      typescript: '>=5.7.2'
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -2443,11 +2446,14 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
-  '@trpc/client@10.45.2(@trpc/server@10.45.2)':
+  '@trpc/client@11.1.0(@trpc/server@11.1.0(typescript@5.7.3))(typescript@5.7.3)':
     dependencies:
-      '@trpc/server': 10.45.2
+      '@trpc/server': 11.1.0(typescript@5.7.3)
+      typescript: 5.7.3
 
-  '@trpc/server@10.45.2': {}
+  '@trpc/server@11.1.0(typescript@5.7.3)':
+    dependencies:
+      typescript: 5.7.3
 
   '@types/aria-query@5.0.4': {}
 
@@ -3928,9 +3934,9 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  trpc-pokemon@2.0.0-next.0(@trpc/server@10.45.2):
+  trpc-pokemon@2.0.0-next.0(@trpc/server@11.1.0(typescript@5.7.3)):
     dependencies:
-      '@trpc/server': 10.45.2
+      '@trpc/server': 11.1.0(typescript@5.7.3)
 
   ts-api-utils@2.0.0(typescript@5.7.3):
     dependencies:

--- a/src/createTRPCJotai.ts
+++ b/src/createTRPCJotai.ts
@@ -73,13 +73,13 @@ const atomWithMutation = <TProcedure extends AnyTRPCMutationProcedure, TClient>(
   path: string[],
   getClient: (get: Getter) => TClient,
 ) => {
-  type Args = inferProcedureInput<TProcedure>;
+  type Input = inferProcedureInput<TProcedure>;
   type Output = inferProcedureOutput<TProcedure>;
   const mutationAtom = atom(
     null as Output | null,
-    async (get, set, args: Args) => {
+    async (get, set, input: Input) => {
       const procedure = getProcedure(getClient(get), path);
-      const result: Output = await procedure.mutate(args);
+      const result: Output = await procedure.mutate(input);
       set(mutationAtom, result);
       return result;
     },

--- a/src/createTRPCJotai.ts
+++ b/src/createTRPCJotai.ts
@@ -77,9 +77,9 @@ const atomWithMutation = <TProcedure extends AnyTRPCMutationProcedure, TClient>(
   type Output = inferProcedureOutput<TProcedure>;
   const mutationAtom = atom(
     null as Output | null,
-    async (get, set, [args]: [Args]) => {
+    async (get, set, args: Args) => {
       const procedure = getProcedure(getClient(get), path);
-      const result: Output = await procedure.mutate(...(args as unknown[]));
+      const result: Output = await procedure.mutate(args);
       set(mutationAtom, result);
       return result;
     },

--- a/src/createTRPCJotai.ts
+++ b/src/createTRPCJotai.ts
@@ -1,11 +1,11 @@
+import type { CreateTRPCClientOptions, TRPCRequestOptions } from '@trpc/client';
 import { createTRPCProxyClient } from '@trpc/client';
-import type { TRPCRequestOptions, CreateTRPCClientOptions } from '@trpc/client';
 import type {
-  AnyMutationProcedure,
-  AnyProcedure,
-  AnyQueryProcedure,
-  AnySubscriptionProcedure,
-  AnyRouter,
+  AnyTRPCMutationProcedure,
+  AnyTRPCProcedure,
+  AnyTRPCQueryProcedure,
+  AnyTRPCRouter,
+  AnyTRPCSubscriptionProcedure,
   ProcedureArgs,
   ProcedureRouterRecord,
   inferProcedureInput,
@@ -13,8 +13,8 @@ import type {
 } from '@trpc/server';
 import type { inferObservableValue } from '@trpc/server/observable';
 
-import { atom } from 'jotai/vanilla';
 import type { Atom, Getter, WritableAtom } from 'jotai/vanilla';
+import { atom } from 'jotai/vanilla';
 import { atomWithObservable } from 'jotai/vanilla/utils';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -39,7 +39,7 @@ export const DISABLED = Symbol();
 
 type CustomOptions = { disabledOutput?: unknown };
 
-const atomWithQuery = <TProcedure extends AnyQueryProcedure, TClient>(
+const atomWithQuery = <TProcedure extends AnyTRPCQueryProcedure, TClient>(
   path: string[],
   getClient: (get: Getter) => TClient,
   getInput: AsyncValueOrGetter<
@@ -69,7 +69,7 @@ const atomWithQuery = <TProcedure extends AnyQueryProcedure, TClient>(
   return queryAtom;
 };
 
-const atomWithMutation = <TProcedure extends AnyMutationProcedure, TClient>(
+const atomWithMutation = <TProcedure extends AnyTRPCMutationProcedure, TClient>(
   path: string[],
   getClient: (get: Getter) => TClient,
 ) => {
@@ -88,7 +88,7 @@ const atomWithMutation = <TProcedure extends AnyMutationProcedure, TClient>(
 };
 
 const atomWithSubscription = <
-  TProcedure extends AnySubscriptionProcedure,
+  TProcedure extends AnyTRPCSubscriptionProcedure,
   TClient,
 >(
   path: string[],
@@ -122,7 +122,7 @@ const atomWithSubscription = <
   return subscriptionAtom;
 };
 
-type QueryResolver<TProcedure extends AnyProcedure, TClient> = {
+type QueryResolver<TProcedure extends AnyTRPCProcedure, TClient> = {
   (
     getInput: AsyncValueOrGetter<ProcedureArgs<TProcedure['_def']>[0]>,
     getOptions?: ValueOrGetter<ProcedureArgs<TProcedure['_def']>[1]>,
@@ -156,7 +156,7 @@ type QueryResolver<TProcedure extends AnyProcedure, TClient> = {
   >;
 };
 
-type MutationResolver<TProcedure extends AnyProcedure, TClient> = (
+type MutationResolver<TProcedure extends AnyTRPCProcedure, TClient> = (
   getClient?: (get: Getter) => TClient,
 ) => WritableAtom<
   inferProcedureOutput<TProcedure> | null,
@@ -164,24 +164,24 @@ type MutationResolver<TProcedure extends AnyProcedure, TClient> = (
   Promise<inferProcedureOutput<TProcedure>>
 >;
 
-type SubscriptionResolver<TProcedure extends AnyProcedure, TClient> = (
+type SubscriptionResolver<TProcedure extends AnyTRPCProcedure, TClient> = (
   getInput: ValueOrGetter<ProcedureArgs<TProcedure['_def']>[0]>,
   getOptions?: ValueOrGetter<ProcedureArgs<TProcedure['_def']>[1]>,
   getClient?: (get: Getter) => TClient,
 ) => Atom<inferObservableValue<inferProcedureOutput<TProcedure>>>;
 
 type DecorateProcedure<
-  TProcedure extends AnyProcedure,
+  TProcedure extends AnyTRPCProcedure,
   TClient,
-> = TProcedure extends AnyQueryProcedure
+> = TProcedure extends AnyTRPCQueryProcedure
   ? {
       atomWithQuery: QueryResolver<TProcedure, TClient>;
     }
-  : TProcedure extends AnyMutationProcedure
+  : TProcedure extends AnyTRPCMutationProcedure
     ? {
         atomWithMutation: MutationResolver<TProcedure, TClient>;
       }
-    : TProcedure extends AnySubscriptionProcedure
+    : TProcedure extends AnyTRPCSubscriptionProcedure
       ? {
           atomWithSubscription: SubscriptionResolver<TProcedure, TClient>;
         }
@@ -191,14 +191,14 @@ type DecoratedProcedureRecord<
   TProcedures extends ProcedureRouterRecord,
   TClient,
 > = {
-  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
+  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyTRPCRouter
     ? DecoratedProcedureRecord<TProcedures[TKey]['_def']['record'], TClient>
-    : TProcedures[TKey] extends AnyProcedure
+    : TProcedures[TKey] extends AnyTRPCProcedure
       ? DecorateProcedure<TProcedures[TKey], TClient>
       : never;
 };
 
-export function createTRPCJotai<TRouter extends AnyRouter>(
+export function createTRPCJotai<TRouter extends AnyTRPCRouter>(
   opts: CreateTRPCClientOptions<TRouter>,
 ) {
   const client = createTRPCProxyClient<TRouter>(opts);


### PR DESCRIPTION
This works, but trpc-pokemon hasn't been updated to trpc@11, so the types in the examples are broken.